### PR TITLE
return missing Framework.Web project dependency to PDS.WITSMLstudio.Desktop.sln

### DIFF
--- a/src/PDS.WITSMLstudio.Desktop.sln
+++ b/src/PDS.WITSMLstudio.Desktop.sln
@@ -76,6 +76,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Store.Web", "..\ext\witsml\
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Store", "..\ext\witsml\src\Store\Store.csproj", "{9E51075C-D571-42F5-A311-0589231DBA9C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Framework.Web", "..\ext\witsml\src\Framework.Web\Framework.Web.csproj", "{90A1FD9F-6A85-4AD2-8523-1360034DCD76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -182,6 +184,10 @@ Global
 		{9E51075C-D571-42F5-A311-0589231DBA9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9E51075C-D571-42F5-A311-0589231DBA9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9E51075C-D571-42F5-A311-0589231DBA9C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{90A1FD9F-6A85-4AD2-8523-1360034DCD76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{90A1FD9F-6A85-4AD2-8523-1360034DCD76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{90A1FD9F-6A85-4AD2-8523-1360034DCD76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{90A1FD9F-6A85-4AD2-8523-1360034DCD76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -210,6 +216,7 @@ Global
 		{987B6304-B4A6-4D57-ACC3-7209175286A6} = {D1BEE84A-E1A1-413D-949A-406B4809BCF4}
 		{347D0962-B422-4ACB-97AA-4BB78854A282} = {D1BEE84A-E1A1-413D-949A-406B4809BCF4}
 		{5FF377F4-56C5-49D9-BA0A-1955A33C4902} = {D1BEE84A-E1A1-413D-949A-406B4809BCF4}
+		{90A1FD9F-6A85-4AD2-8523-1360034DCD76} = {2B7ADB7E-EF7C-4FBD-ADFB-CA0EF611F82C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {B2B8135B-B697-4041-AE0F-158360104F8C}


### PR DESCRIPTION
First of all thank you for opensourcing this piece of software. it really helped me implementing my own WITSML client. 
### So, to the pull request
Everything goes well if you first open witsml repo solution and build it, and then build the Desktop solution. But if you try to build PDS.WITSMLstudio.Desktop.sln just after cloning the repo, it says something like that
![not_found](https://user-images.githubusercontent.com/28512901/112721429-bbee3300-8f14-11eb-906b-92d784cc978f.PNG)
(sorry for russian here, but it says something like `"PDS.WITSMLstudio.Framework.Web.dll"` is missing).

### What I did
I added reference to the Frameworl.Web project here
![include](https://user-images.githubusercontent.com/28512901/112721510-2f904000-8f15-11eb-8126-094f6dfeae40.PNG),
so the Desktop solution now builds just after cloning with --recurse-submodules parameter and pressing Ctrl+Shift+B.
